### PR TITLE
fix: stop using browser prop in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "main": "cjs/index.js",
   "module": "esm/index.js",
-  "browser": "dist/isMobile.min.js",
+  "jsdelivr": "dist/isMobile.min.js",
   "types": "types",
   "scripts": {
     "prebuild": "rm -rf cjs esm dist",


### PR DESCRIPTION
use of browser property in package.json was causing webpack to break by using `dist`  copy for jsDelivr 😅 

fix #94